### PR TITLE
Add account controller for handling account API routes

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,2 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
+require_once __DIR__ . '/src/AccountController.php';
+
+$controller = new AccountController();
+
+$uri = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
+$uri = rtrim($uri, '/') ?: '/';
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+switch (true) {
+    case $uri === '/reset' && $method === 'POST':
+        $controller->reset();
+        break;
+
+    case $uri === '/accounts' && $method === 'GET':
+        $controller->list();
+        break;
+
+    case $uri === '/accounts' && $method === 'POST':
+        $controller->create();
+        break;
+
+    case preg_match('#^/account/(\d+)$#', $uri, $matches) === 1 && $method === 'GET':
+        $controller->get((int) $matches[1]);
+        break;
+
+    case preg_match('#^/account/(\d+)$#', $uri, $matches) === 1 && $method === 'PATCH':
+        $controller->update((int) $matches[1]);
+        break;
+
+    default:
+        http_response_code(404);
+        header('Content-Type: application/json');
+        echo json_encode(['error' => 'Route not found'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        break;
+}

--- a/src/AccountController.php
+++ b/src/AccountController.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+class AccountController
+{
+    private const SESSION_KEY = 'accounts';
+    private const SESSION_NEXT_NUMBER_KEY = 'next_number';
+
+    public function __construct()
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        if (!isset($_SESSION[self::SESSION_KEY], $_SESSION[self::SESSION_NEXT_NUMBER_KEY])) {
+            $this->resetState();
+        }
+    }
+
+    public function reset(): void
+    {
+        $this->resetState();
+        $this->sendResponse([], 205);
+    }
+
+    public function list(): void
+    {
+        $accounts = array_values($_SESSION[self::SESSION_KEY]);
+
+        if (empty($accounts)) {
+            $this->sendResponse([], 404);
+            return;
+        }
+
+        $list = array_map(static fn (array $account) => ['number' => $account['number']], $accounts);
+        $this->sendResponse($list, 200);
+    }
+
+    public function create(): void
+    {
+        $payload = $this->readJsonPayload();
+
+        if ($payload === null || !array_key_exists('balance', $payload)) {
+            $this->sendResponse(['error' => 'Missing "balance" value.'], 400);
+            return;
+        }
+
+        if (!is_numeric($payload['balance'])) {
+            $this->sendResponse(['error' => 'The "balance" must be numeric.'], 422);
+            return;
+        }
+
+        $number = $_SESSION[self::SESSION_NEXT_NUMBER_KEY]++;
+        $balance = (float) $payload['balance'];
+
+        $_SESSION[self::SESSION_KEY][$number] = [
+            'number' => $number,
+            'balance' => $balance,
+        ];
+
+        $this->sendResponse(['number' => $number], 201);
+    }
+
+    public function get(int $number): void
+    {
+        $account = $this->findAccount($number);
+
+        if ($account === null) {
+            $this->sendResponse([], 404);
+            return;
+        }
+
+        $this->sendResponse($account, 200);
+    }
+
+    public function update(int $number): void
+    {
+        $account = $this->findAccount($number);
+
+        if ($account === null) {
+            $this->sendResponse([], 404);
+            return;
+        }
+
+        $payload = $this->readJsonPayload();
+
+        if ($payload === null || !array_key_exists('balance', $payload)) {
+            $this->sendResponse(['error' => 'Missing "balance" value.'], 400);
+            return;
+        }
+
+        if (!is_numeric($payload['balance'])) {
+            $this->sendResponse(['error' => 'The "balance" must be numeric.'], 422);
+            return;
+        }
+
+        $account['balance'] = (float) $payload['balance'];
+        $_SESSION[self::SESSION_KEY][$number] = $account;
+
+        $this->sendResponse($account, 201);
+    }
+
+    private function resetState(): void
+    {
+        $_SESSION[self::SESSION_KEY] = [];
+        $_SESSION[self::SESSION_NEXT_NUMBER_KEY] = 1;
+    }
+
+    private function findAccount(int $number): ?array
+    {
+        return $_SESSION[self::SESSION_KEY][$number] ?? null;
+    }
+
+    private function readJsonPayload(): ?array
+    {
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+        if (stripos($contentType, 'application/json') === false) {
+            return null;
+        }
+
+        $raw = file_get_contents('php://input');
+        if ($raw === false || $raw === '') {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        return $decoded;
+    }
+
+    private function sendResponse($data, int $statusCode): void
+    {
+        http_response_code($statusCode);
+        header('Content-Type: application/json');
+        echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+}


### PR DESCRIPTION
## Summary
- add an AccountController to manage account data in the session and validate JSON payloads
- wire index.php to route incoming requests to the controller methods and return JSON responses

## Testing
- php -l index.php
- php -l src/AccountController.php

------
https://chatgpt.com/codex/tasks/task_e_68e5ac6872fc832cb0af73c47cf8f9d6